### PR TITLE
fix: PDV-85-Spring-Boot-upgrade

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -69,6 +69,8 @@ jobs:
             matrixStringifiedObject="{\"include\":[{\"environment\":\"prod\", \"env_short\": \"p\"}]}"
           elif [ ${{ github.event.pull_request.base.ref == 'release-uat' }} == true ]; then
             matrixStringifiedObject="{\"include\":[{\"environment\":\"uat\", \"env_short\": \"u\"}]}"
+          elif [ ${{ github.event.pull_request.base.ref == 'release-dev' }} == true ]; then
+            matrixStringifiedObject="{\"include\":[{\"environment\":\"dev\", \"env_short\": \"d\"}]}"          
           else
             matrixStringifiedObject=""
           fi

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -8,7 +8,15 @@ on:
       - "**/src/**"
       - "**pom.xml"
       - ".github/workflows/code-review.yml"
-
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+    paths:
+      - "**/src/**"
+      - "**pom.xml"
+      - ".github/workflows/code-review.yml"
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -27,6 +27,7 @@ jobs:
             docs
             chore
             breaking
+            ci
           # Configure that a scope must always be provided.
           requireScope: false
           # Configure additional validation for the subject based on a regex.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine-jre
-ADD https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.1.1/applicationinsights-agent-3.1.1.jar /applicationinsights-agent.jar
+FROM adoptopenjdk/openjdk11:alpine-jre@sha256:789f551fca5e233b1593aee65283d5981b3a82284e15a8cad4c798315188f848
 VOLUME /tmp
 COPY target/*.jar app.jar
 ENTRYPOINT ["java","-jar","app.jar"]
-

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -14,6 +14,7 @@ spring:
     include:
       # TO enable specific-language documentations
       - swaggerEN
+      - ${APP_PROFILE_LOCAL}
   zipkin:
     enabled: false
   sleuth:
@@ -26,6 +27,11 @@ info:
     name: "@project.parent.artifactId@"
     description: "@project.description@"
     version: "@project.version@"
+
+springdoc:
+  api-docs:
+    resolve-schema-properties: true
+  writer-with-order-by-keys: true
 
 logging:
   level:

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1,29 +1,23 @@
 {
-  "openapi" : "3.0.3",
+  "openapi" : "3.0.1",
   "info" : {
-    "title" : "pdv-ms-tokenizer",
     "description" : "Tokenizer API documentation",
+    "title" : "pdv-ms-tokenizer",
     "version" : "1.0-SNAPSHOT"
   },
   "servers" : [ {
-    "url" : "http://localhost:80",
-    "description" : "Inferred Url"
-  } ],
-  "tags" : [ {
-    "name" : "token",
-    "description" : "Token operations"
+    "url" : "http://localhost",
+    "description" : "Generated server url"
   } ],
   "paths" : {
     "/tokens" : {
       "put" : {
-        "tags" : [ "token" ],
-        "summary" : "Upsert token",
         "description" : "Create a new token given a PII and Namespace, if already exists do nothing",
-        "operationId" : "saveUsingPUT",
+        "operationId" : "save",
         "parameters" : [ {
-          "name" : "x-pagopa-namespace",
-          "in" : "header",
           "description" : "Caller visibility context",
+          "in" : "header",
+          "name" : "x-pagopa-namespace",
           "required" : true,
           "schema" : {
             "type" : "string"
@@ -36,62 +30,63 @@
                 "$ref" : "#/components/schemas/PiiResource"
               }
             }
-          }
+          },
+          "required" : true
         },
         "responses" : {
           "200" : {
-            "description" : "OK",
             "content" : {
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/TokenResource"
                 }
               }
-            }
+            },
+            "description" : "OK"
           },
           "400" : {
-            "description" : "Bad Request",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Bad Request"
           },
           "429" : {
-            "description" : "Too Many Requests",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Too Many Requests"
           },
           "500" : {
-            "description" : "Internal Server Error",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Internal Server Error"
           }
-        }
+        },
+        "summary" : "Upsert token",
+        "tags" : [ "token" ]
       }
     },
     "/tokens/search" : {
       "post" : {
-        "tags" : [ "token" ],
-        "summary" : "Search token",
         "description" : "Search a token given a PII and Namespace",
-        "operationId" : "searchUsingPOST",
+        "operationId" : "search",
         "parameters" : [ {
-          "name" : "x-pagopa-namespace",
-          "in" : "header",
           "description" : "Caller visibility context",
+          "in" : "header",
+          "name" : "x-pagopa-namespace",
           "required" : true,
           "schema" : {
             "type" : "string"
@@ -104,82 +99,82 @@
                 "$ref" : "#/components/schemas/PiiResource"
               }
             }
-          }
+          },
+          "required" : true
         },
         "responses" : {
           "200" : {
-            "description" : "OK",
             "content" : {
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/TokenResource"
                 }
               }
-            }
+            },
+            "description" : "OK"
           },
           "400" : {
-            "description" : "Bad Request",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Bad Request"
           },
           "404" : {
-            "description" : "Not Found",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Not Found"
           },
           "429" : {
-            "description" : "Too Many Requests",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Too Many Requests"
           },
           "500" : {
-            "description" : "Internal Server Error",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Internal Server Error"
           }
-        }
+        },
+        "summary" : "Search token",
+        "tags" : [ "token" ]
       }
     },
     "/tokens/{token}/pii" : {
       "get" : {
-        "tags" : [ "token" ],
-        "summary" : "Find PII",
         "description" : "Find a PII given a token",
-        "operationId" : "findPiiUsingGET",
+        "operationId" : "findPii",
         "parameters" : [ {
-          "name" : "token",
-          "in" : "path",
           "description" : "Token related to the PII",
+          "in" : "path",
+          "name" : "token",
           "required" : true,
-          "style" : "simple",
           "schema" : {
             "type" : "string",
             "format" : "uuid"
           }
         }, {
-          "name" : "x-pagopa-namespace",
-          "in" : "header",
           "description" : "Caller visibility context",
+          "in" : "header",
+          "name" : "x-pagopa-namespace",
           "required" : true,
           "schema" : {
             "type" : "string"
@@ -187,65 +182,66 @@
         } ],
         "responses" : {
           "200" : {
-            "description" : "OK",
             "content" : {
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/PiiResource"
                 }
               }
-            }
+            },
+            "description" : "OK"
           },
           "400" : {
-            "description" : "Bad Request",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Bad Request"
           },
           "404" : {
-            "description" : "Not Found",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Not Found"
           },
           "429" : {
-            "description" : "Too Many Requests",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Too Many Requests"
           },
           "500" : {
-            "description" : "Internal Server Error",
             "content" : {
               "application/problem+json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/Problem"
                 }
               }
-            }
+            },
+            "description" : "Internal Server Error"
           }
-        }
+        },
+        "summary" : "Find PII",
+        "tags" : [ "token" ]
       }
     }
   },
   "components" : {
     "schemas" : {
       "InvalidParam" : {
-        "title" : "InvalidParam",
-        "required" : [ "name", "reason" ],
         "type" : "object",
+        "description" : "A list of invalid parameters details.",
         "properties" : {
           "name" : {
             "type" : "string",
@@ -255,23 +251,22 @@
             "type" : "string",
             "description" : "Invalid parameter reason."
           }
-        }
+        },
+        "required" : [ "name", "reason" ]
       },
       "PiiResource" : {
-        "title" : "PiiResource",
-        "required" : [ "pii" ],
         "type" : "object",
         "properties" : {
           "pii" : {
             "type" : "string",
             "description" : "Personal Identifiable Information"
           }
-        }
+        },
+        "required" : [ "pii" ]
       },
       "Problem" : {
-        "title" : "Problem",
-        "required" : [ "status", "title" ],
         "type" : "object",
+        "description" : "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)",
         "properties" : {
           "detail" : {
             "type" : "string",
@@ -289,6 +284,8 @@
             }
           },
           "status" : {
+            "maximum" : 599,
+            "minimum" : 100,
             "type" : "integer",
             "description" : "The HTTP status code.",
             "format" : "int32",
@@ -303,11 +300,9 @@
             "description" : "A URL to a page with more details regarding the problem."
           }
         },
-        "description" : "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)"
+        "required" : [ "status", "title" ]
       },
       "TokenResource" : {
-        "title" : "TokenResource",
-        "required" : [ "rootToken", "token" ],
         "type" : "object",
         "properties" : {
           "rootToken" : {
@@ -320,7 +315,8 @@
             "description" : "Namespaced token related to the PII",
             "format" : "uuid"
           }
-        }
+        },
+        "required" : [ "rootToken", "token" ]
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.5</version>
+        <version>2.7.13</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <artifactId>pdv-ms-tokenizer</artifactId>
@@ -19,7 +19,7 @@
         <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spring-cloud.version>2020.0.4</spring-cloud.version>
+        <spring-cloud.version>2021.0.8</spring-cloud.version>
     </properties>
 
     <dependencyManagement>
@@ -64,9 +64,9 @@
                 <type>test-jar</type>
             </dependency>
             <dependency>
-                <groupId>io.springfox</groupId>
-                <artifactId>springfox-boot-starter</artifactId>
-                <version>3.0.0</version>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-ui</artifactId>
+                <version>1.7.0</version>
             </dependency>
             <!-- https://mvnrepository.com/artifact/net.logstash.logback/logstash-logback-encoder -->
             <dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -20,8 +20,8 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-boot-starter</artifactId>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
         </dependency>
         <dependency>
             <groupId>it.pagopa.pdv</groupId>

--- a/web/src/main/java/it/pagopa/pdv/tokenizer/web/annotations/CommonApiResponsesWrapper.java
+++ b/web/src/main/java/it/pagopa/pdv/tokenizer/web/annotations/CommonApiResponsesWrapper.java
@@ -1,0 +1,44 @@
+package it.pagopa.pdv.tokenizer.web.annotations;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import it.pagopa.pdv.tokenizer.web.model.Problem;
+import org.springframework.http.MediaType;
+
+import java.lang.annotation.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@ApiResponses(
+        value = {
+                @ApiResponse(
+                        responseCode = "500",
+                        description = "Internal Server Error",
+                        content = {
+                                @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                        schema = @Schema(implementation = Problem.class))
+                        }
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Bad Request",
+                        content = {
+                                @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                        schema = @Schema(implementation = Problem.class))
+                        }
+                ),
+                @ApiResponse(
+                        responseCode = "429",
+                        description = "Too Many Requests",
+                        content = {
+                                @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                                        schema = @Schema(implementation = Problem.class))
+                        }
+                )
+        }
+)
+public @interface CommonApiResponsesWrapper {
+}

--- a/web/src/main/java/it/pagopa/pdv/tokenizer/web/config/SwaggerConfig.java
+++ b/web/src/main/java/it/pagopa/pdv/tokenizer/web/config/SwaggerConfig.java
@@ -1,89 +1,32 @@
 package it.pagopa.pdv.tokenizer.web.config;
 
-import com.fasterxml.classmate.TypeResolver;
-import it.pagopa.pdv.tokenizer.web.model.Problem;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.*;
 import org.springframework.core.env.Environment;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.builders.ResponseBuilder;
-import springfox.documentation.service.Response;
-import springfox.documentation.service.Tag;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
 
-import java.time.LocalTime;
-import java.util.List;
 
 @Slf4j
 @Configuration
+@ComponentScan(basePackageClasses = SwaggerConfig.class)
 class SwaggerConfig {
 
-    public static final Response INTERNAL_SERVER_ERROR_RESPONSE = new ResponseBuilder()
-            .code(String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR.value()))
-            .description(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase())
-            .representation(MediaType.APPLICATION_PROBLEM_JSON).apply(repBuilder ->
-                    repBuilder.model(modelSpecBuilder ->
-                            modelSpecBuilder.referenceModel(refModelSpecBuilder ->
-                                    refModelSpecBuilder.key(modelKeyBuilder ->
-                                            modelKeyBuilder.qualifiedModelName(qualifiedModelNameBuilder ->
-                                                    qualifiedModelNameBuilder.namespace(Problem.class.getPackageName())
-                                                            .name(Problem.class.getSimpleName()))))))
-            .build();
-    private static final Response BAD_REQUEST_RESPONSE = new ResponseBuilder()
-            .code(String.valueOf(HttpStatus.BAD_REQUEST.value()))
-            .description(HttpStatus.BAD_REQUEST.getReasonPhrase())
-            .representation(MediaType.APPLICATION_PROBLEM_JSON).apply(repBuilder ->
-                    repBuilder.model(modelSpecBuilder ->
-                            modelSpecBuilder.referenceModel(refModelSpecBuilder ->
-                                    refModelSpecBuilder.key(modelKeyBuilder ->
-                                            modelKeyBuilder.qualifiedModelName(qualifiedModelNameBuilder ->
-                                                    qualifiedModelNameBuilder.namespace(Problem.class.getPackageName())
-                                                            .name(Problem.class.getSimpleName()))))))
-            .build();
-    private static final Response NOT_FOUND_RESPONSE = new ResponseBuilder()
-            .code(String.valueOf(HttpStatus.NOT_FOUND.value()))
-            .description(HttpStatus.NOT_FOUND.getReasonPhrase())
-            .representation(MediaType.APPLICATION_PROBLEM_JSON).apply(repBuilder ->
-                    repBuilder.model(modelSpecBuilder ->
-                            modelSpecBuilder.referenceModel(refModelSpecBuilder ->
-                                    refModelSpecBuilder.key(modelKeyBuilder ->
-                                            modelKeyBuilder.qualifiedModelName(qualifiedModelNameBuilder ->
-                                                    qualifiedModelNameBuilder.namespace(Problem.class.getPackageName())
-                                                            .name(Problem.class.getSimpleName()))))))
-            .build();
-
-    private static final Response TOO_MANY_REQUESTS_RESPONSE = new ResponseBuilder()
-            .code(String.valueOf(HttpStatus.TOO_MANY_REQUESTS.value()))
-            .description(HttpStatus.TOO_MANY_REQUESTS.getReasonPhrase())
-            .representation(MediaType.APPLICATION_PROBLEM_JSON).apply(repBuilder ->
-                    repBuilder.model(modelSpecBuilder ->
-                            modelSpecBuilder.referenceModel(refModelSpecBuilder ->
-                                    refModelSpecBuilder.key(modelKeyBuilder ->
-                                            modelKeyBuilder.qualifiedModelName(qualifiedModelNameBuilder ->
-                                                    qualifiedModelNameBuilder.namespace(Problem.class.getPackageName()).name(Problem.class.getSimpleName()))))))
-            .build();
 
     @Configuration
     @Profile("swaggerIT")
     @PropertySource("classpath:/swagger/swagger_it.properties")
-    public static class itConfig {
+    public static class ItConfig {
     }
 
     @Configuration
     @Profile("swaggerEN")
     @PropertySource("classpath:/swagger/swagger_en.properties")
-    public static class enConfig {
+    public static class EnConfig {
     }
+
 
     private final Environment environment;
 
@@ -95,26 +38,14 @@ class SwaggerConfig {
         this.environment = environment;
     }
 
-
     @Bean
-    public Docket swaggerSpringPlugin(@Autowired TypeResolver typeResolver) {
-        return (new Docket(DocumentationType.OAS_30))
-                .apiInfo(new ApiInfoBuilder()
+    public OpenAPI swaggerOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
                         .title(environment.getProperty("swagger.title", environment.getProperty("spring.application.name")))
                         .description(environment.getProperty("swagger.description", "Api and Models"))
-                        .version(environment.getProperty("swagger.version", environment.getProperty("spring.application.version")))
-                        .build())
-                .select().apis(RequestHandlerSelectors.basePackage("it.pagopa.pdv.tokenizer.web.controller")).build()
-                .tags(new Tag("token", environment.getProperty("swagger.tag.token.description")))
-                .directModelSubstitute(LocalTime.class, String.class)
-                .useDefaultResponseMessages(false)
-                .globalResponses(HttpMethod.GET, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, NOT_FOUND_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
-                .globalResponses(HttpMethod.DELETE, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
-                .globalResponses(HttpMethod.POST, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
-                .globalResponses(HttpMethod.PUT, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
-                .globalResponses(HttpMethod.PATCH, List.of(INTERNAL_SERVER_ERROR_RESPONSE, BAD_REQUEST_RESPONSE, TOO_MANY_REQUESTS_RESPONSE))
-                .additionalModels(typeResolver.resolve(Problem.class))
-                .forCodeGeneration(true);
+                        .version(environment.getProperty("swagger.version", environment.getProperty("spring.application.version"))));
     }
+
 
 }

--- a/web/src/main/java/it/pagopa/pdv/tokenizer/web/controller/TokenizerController.java
+++ b/web/src/main/java/it/pagopa/pdv/tokenizer/web/controller/TokenizerController.java
@@ -1,18 +1,20 @@
 package it.pagopa.pdv.tokenizer.web.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.pdv.tokenizer.connector.model.TokenDto;
 import it.pagopa.pdv.tokenizer.core.TokenizerService;
+import it.pagopa.pdv.tokenizer.web.annotations.CommonApiResponsesWrapper;
 import it.pagopa.pdv.tokenizer.web.model.PiiResource;
 import it.pagopa.pdv.tokenizer.web.model.Problem;
 import it.pagopa.pdv.tokenizer.web.model.TokenResource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,7 +26,7 @@ import static it.pagopa.pdv.tokenizer.core.logging.LogUtils.CONFIDENTIAL_MARKER;
 @Slf4j
 @RestController
 @RequestMapping(value = "tokens", produces = MediaType.APPLICATION_JSON_VALUE)
-@Api(tags = "token")
+@Tag(name = "token")
 public class TokenizerController {
 
     private static final String NAMESPACE_HEADER_NAME = "x-pagopa-namespace";
@@ -39,10 +41,12 @@ public class TokenizerController {
     }
 
 
-    @ApiOperation(value = "${swagger.api.tokens.save.summary}",
-            notes = "${swagger.api.tokens.save.notes}")
+    @Operation(summary = "${swagger.api.tokens.save.summary}",
+            description = "${swagger.api.tokens.save.notes}")
+    @CommonApiResponsesWrapper
     @PutMapping(value = "")
-    public TokenResource save(@ApiParam("${swagger.model.namespace}")
+    @ResponseStatus(HttpStatus.OK)
+    public TokenResource save(@Parameter(description = "${swagger.model.namespace}")
                               @RequestHeader(NAMESPACE_HEADER_NAME)
                                       String namespace,
                               @RequestBody
@@ -60,8 +64,9 @@ public class TokenizerController {
     }
 
 
-    @ApiOperation(value = "${swagger.api.tokens.search.summary}",
-            notes = "${swagger.api.tokens.search.notes}")
+    @Operation(summary = "${swagger.api.tokens.search.summary}",
+            description = "${swagger.api.tokens.search.notes}")
+    @CommonApiResponsesWrapper
     @ApiResponse(responseCode = "404",
             description = "Not Found",
             content = {
@@ -69,7 +74,8 @@ public class TokenizerController {
                             schema = @Schema(implementation = Problem.class))
             })
     @PostMapping(value = "search")
-    public TokenResource search(@ApiParam("${swagger.model.namespace}")
+    @ResponseStatus(HttpStatus.OK)
+    public TokenResource search(@Parameter(description = "${swagger.model.namespace}")
                                 @RequestHeader(NAMESPACE_HEADER_NAME)
                                         String namespace,
                                 @RequestBody
@@ -87,12 +93,20 @@ public class TokenizerController {
     }
 
 
-    @ApiOperation(value = "${swagger.api.tokens.findPii.summary}",
-            notes = "${swagger.api.tokens.findPii.notes}")
+    @Operation(summary = "${swagger.api.tokens.findPii.summary}",
+            description = "${swagger.api.tokens.findPii.notes}")
+    @CommonApiResponsesWrapper
+    @ApiResponse(responseCode = "404",
+            description = "Not Found",
+            content = {
+                    @Content(mediaType = MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+                            schema = @Schema(implementation = Problem.class))
+            })
     @GetMapping(value = "{token}/pii")
-    public PiiResource findPii(@ApiParam("${swagger.model.token}")
+    @ResponseStatus(HttpStatus.OK)
+    public PiiResource findPii(@Parameter(description = "${swagger.model.token}")
                                @PathVariable UUID token,
-                               @ApiParam("${swagger.model.namespace}")
+                               @Parameter(description = "${swagger.model.namespace}")
                                @RequestHeader(NAMESPACE_HEADER_NAME)
                                String namespace) {
         log.trace("[findPii] start");

--- a/web/src/main/java/it/pagopa/pdv/tokenizer/web/model/PiiResource.java
+++ b/web/src/main/java/it/pagopa/pdv/tokenizer/web/model/PiiResource.java
@@ -1,6 +1,6 @@
 package it.pagopa.pdv.tokenizer.web.model;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotBlank;
 @Data
 public class PiiResource {
 
-    @ApiModelProperty(value = "${swagger.model.token.pii}", required = true)
+    @Schema(description = "${swagger.model.token.pii}", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank
     private String pii;
 

--- a/web/src/main/java/it/pagopa/pdv/tokenizer/web/model/Problem.java
+++ b/web/src/main/java/it/pagopa/pdv/tokenizer/web/model/Problem.java
@@ -1,7 +1,6 @@
 package it.pagopa.pdv.tokenizer.web.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,28 +17,28 @@ import java.util.List;
 
 @Data
 @NoArgsConstructor
-@ApiModel(description = "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)")
+@Schema(description = "A \"problem detail\" as a way to carry machine-readable details of errors (https://datatracker.ietf.org/doc/html/rfc7807)")
 public class Problem implements Serializable {
 
-    @ApiModelProperty(value = "A URL to a page with more details regarding the problem.")
+    @Schema(description = "A URL to a page with more details regarding the problem.")
     private String type;
 
-    @ApiModelProperty(value = "Short human-readable summary of the problem.", required = true)
+    @Schema(description = "Short human-readable summary of the problem.", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank
     private String title;
 
-    @ApiModelProperty(value = "The HTTP status code.", required = true, example = "500")
+    @Schema(description = "The HTTP status code.", requiredMode = Schema.RequiredMode.REQUIRED, example = "500")
     @Min(100)
     @Max(599)
     private int status;
 
-    @ApiModelProperty(value = "Human-readable description of this specific problem.")
+    @Schema(description = "Human-readable description of this specific problem.")
     private String detail;
 
-    @ApiModelProperty(value = "A URI that describes where the problem occurred.")
+    @Schema(description = "A URI that describes where the problem occurred.")
     private String instance;
 
-    @ApiModelProperty(value = "A list of invalid parameters details.")
+    @Schema(description = "A list of invalid parameters details.")
     private List<InvalidParam> invalidParams;
 
 
@@ -69,11 +68,11 @@ public class Problem implements Serializable {
     @AllArgsConstructor
     public static class InvalidParam {
 
-        @ApiModelProperty(value = "Invalid parameter name.", required = true)
+        @Schema(description = "Invalid parameter name.", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank
         private String name;
 
-        @ApiModelProperty(value = "Invalid parameter reason.", required = true)
+        @Schema(description = "Invalid parameter reason.", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank
         private String reason;
 

--- a/web/src/main/java/it/pagopa/pdv/tokenizer/web/model/TokenResource.java
+++ b/web/src/main/java/it/pagopa/pdv/tokenizer/web/model/TokenResource.java
@@ -1,6 +1,6 @@
 package it.pagopa.pdv.tokenizer.web.model;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
@@ -9,10 +9,10 @@ import java.util.UUID;
 @Data
 public class TokenResource {
 
-    @ApiModelProperty(value = "${swagger.model.token.token}", required = true)
+    @Schema(description = "${swagger.model.token.token}", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull
     private UUID token;
-    @ApiModelProperty(value = "${swagger.model.token.rootToken}", required = true)
+    @Schema(description = "${swagger.model.token.rootToken}", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull
     private UUID rootToken;
 


### PR DESCRIPTION
This PR will be merged on 22.08.2023

This PR upgrades `spring-boot` version from `2.5.5` to `2.7.13 `and `spring-cloud` from `2020.0.4` to `2021.0.8`.
This introduces some refactoring code for the replacing of `springfox` with `springdoc`

Other minor changes:
- Setup dev environment for deploy pipeline
- **OER task 85** (github workflow)
- **OER task 81** (docker pinning java image)