### PR TITLE
ci: Split deploy job to set more granular permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,8 +51,7 @@ jobs:
             matrixStringifiedObject=""
           fi
           
-          echo "matrix=$matrixStringifiedObject" >> $GITHUB_OUTPUT          
-      
+          echo "matrix=$matrixStringifiedObject" >> $GITHUB_OUTPUT
   deploy:
     name: "Deploy on ECS"
     if: ${{ needs.build.outputs.matrix != '' }}
@@ -60,10 +59,10 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
-      contents: write
+      contents: read
     strategy:
         matrix: ${{ fromJson(needs.build.outputs.matrix) }}
-         
+
     continue-on-error: false
     environment: ${{ matrix.environment }}
     env:
@@ -71,19 +70,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-      - name: Release
-        if: ${{ matrix.environment == 'prod' }}
-        id: release
-        # from https://github.com/cycjimmy/semantic-release-action/commits/main
-        uses: cycjimmy/semantic-release-action@bdd914ff2423e2792c73475f11e8da603182f32d
-        with:
-          semantic_version: 18.0.0
-          extra_plugins: |
-            @semantic-release/release-notes-generator@10.0.3
-            @semantic-release/git@10.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
         with:
           name: app-jar
@@ -94,7 +81,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.IAM_ROLE }}
           aws-region: ${{ env.AWS_REGION }}
-      
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@261a7de32bda11ba01f4d75c4ed6caf3739e54be
@@ -109,7 +96,7 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
-      
+
       - name: Download task definition
         run: |
           aws ecs describe-task-definition \
@@ -140,7 +127,28 @@ jobs:
           service: tokenizer-${{ matrix.env_short }}-service-tokenizer
           cluster: tokenizer-${{ matrix.env_short }}-ecs-cluster
           wait-for-service-stability: true
+  release:
+    if: ${{ needs.build.outputs.matrix != '' }}
+    needs: [build, deploy]
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix: ${{ fromJson(needs.build.outputs.matrix) }}
+    environment: ${{ matrix.environment }}
 
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Release
+        if: ${{ matrix.environment == 'prod' }}
+        id: release
+        # from https://github.com/cycjimmy/semantic-release-action/commits/main
+        uses: cycjimmy/semantic-release-action@bdd914ff2423e2792c73475f11e8da603182f32d
+        with:
+          semantic_version: 18.0.0
+          extra_plugins: |
+            @semantic-release/release-notes-generator@10.0.3
+            @semantic-release/git@10.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   k6-integration-tests:
     if: ${{ needs.build.outputs.matrix != '' }}
     name: integration-tests

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -128,6 +128,7 @@ jobs:
           cluster: tokenizer-${{ matrix.env_short }}-ecs-cluster
           wait-for-service-stability: true
   release:
+    name: "Create Release"
     if: ${{ needs.build.outputs.matrix != '' }}
     needs: [build, deploy]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This PR splits the deploy job of the build-and-deploy.yml workflow to give more granular permissions to `release` and `deploy` phase