### PR TITLE
ci: Split deploy job to set more granular permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,14 +4,6 @@ on:
   push:
     branches:
       - "**"
-      - "!main"
-      - "!develop"
-  pull_request:
-    types:
-      - closed
-    branches:
-      - "main"
-      - "develop"
     paths:
       - "**/src/main/**"
       - "**pom.xml"
@@ -51,9 +43,9 @@ jobs:
       - name: Set Dynamic Env Matrix
         id: setmatrix
         run: |
-          if [ ${{ github.event.pull_request.base.ref == 'main' }} == true ]; then 
+          if [ ${{ github.ref == 'refs/heads/main' }} == true ]; then 
             matrixStringifiedObject="{\"include\":[{\"environment\":\"uat\", \"env_short\": \"u\"},{\"environment\":\"prod\", \"env_short\": \"p\"}]}"
-          elif [ ${{ github.event.pull_request.base.ref == 'develop' }} == true ]; then
+          elif [ ${{ github.ref == 'refs/heads/develop' }} == true ]; then
             matrixStringifiedObject="{\"include\":[{\"environment\":\"dev\", \"env_short\": \"d\"}]}"        
           else
             matrixStringifiedObject=""


### PR DESCRIPTION
This PR splits the deploy job of the build-and-deploy.yml workflow to give more granular permissions to `release` and `deploy` phase